### PR TITLE
feat: add agentic layer + MCP server for TrackMyPDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to ".env" and fill in your key (never commit the real .env).
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+# Optional: pick any model your Anthropic account can access.
+ANTHROPIC_MODEL=claude-sonnet-5

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Secrets
+.env
+
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""TrackMyPDB agentic layer: a Claude-powered chat that drives the MCP server."""

--- a/agent/mcp_agent.py
+++ b/agent/mcp_agent.py
@@ -1,0 +1,133 @@
+"""
+Claude agent that connects to the TrackMyPDB MCP server.
+
+Flow for each user message:
+  1. Launch mcp_server.server over stdio (official MCP Python client).
+  2. Discover the server's tools and hand them to Claude.
+  3. Run the tool-use loop: Claude thinks -> calls a tool -> reads the result ->
+     ... -> final answer.
+
+This is what makes the app "agentic AND MCP-native": the same MCP server that
+powers Claude Desktop also powers the in-app chat.
+
+MIT License - Open Source Project.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from contextlib import AsyncExitStack
+
+from anthropic import Anthropic
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+DEFAULT_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-5")
+
+SYSTEM_PROMPT = (
+    "You are TrackMyPDB Assistant, a friendly bioinformatics helper for the "
+    "TrackMyPDB app. You can list PDB structures for a UniProt ID, extract "
+    "drug-like heteroatoms (ligands) and their SMILES from PDB structures, and "
+    "rank molecules by Tanimoto similarity using Morgan fingerprints -- all via "
+    "the provided tools. When the user gives UniProt IDs together with a target "
+    "molecule, use run_pipeline. Keep max_pdbs_per_uniprot small (<=5) unless "
+    "asked, because extraction calls slow public APIs (RCSB, PDBe, PubChem). "
+    "Explain the chemistry in plain language and always show the top hits."
+)
+
+
+def _server_params() -> StdioServerParameters:
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    return StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "mcp_server.server"],
+        env=env,
+    )
+
+
+def _tool_result_text(result) -> str:
+    parts = []
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(text)
+    return "\n".join(parts) if parts else str(result)
+
+
+async def _run(messages, api_key, model, on_event):
+    client = Anthropic(api_key=api_key)
+    async with AsyncExitStack() as stack:
+        read, write = await stack.enter_async_context(stdio_client(_server_params()))
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+
+        tools = (await session.list_tools()).tools
+        anthropic_tools = [{
+            "name": t.name,
+            "description": t.description or "",
+            "input_schema": t.inputSchema,
+        } for t in tools]
+
+        while True:
+            resp = client.messages.create(
+                model=model,
+                max_tokens=2048,
+                system=SYSTEM_PROMPT,
+                tools=anthropic_tools,
+                messages=messages,
+            )
+
+            assistant_content = []
+            tool_uses = []
+            for block in resp.content:
+                if block.type == "text":
+                    assistant_content.append({"type": "text", "text": block.text})
+                elif block.type == "tool_use":
+                    assistant_content.append({
+                        "type": "tool_use", "id": block.id,
+                        "name": block.name, "input": block.input,
+                    })
+                    tool_uses.append(block)
+            messages.append({"role": "assistant", "content": assistant_content})
+
+            if resp.stop_reason != "tool_use":
+                final = "".join(b.text for b in resp.content if b.type == "text")
+                return final, messages
+
+            tool_results = []
+            for tu in tool_uses:
+                if on_event:
+                    on_event({"type": "tool_call", "name": tu.name, "input": tu.input})
+                try:
+                    result = await session.call_tool(tu.name, tu.input or {})
+                    text = _tool_result_text(result)
+                    is_error = bool(getattr(result, "isError", False))
+                except Exception as exc:  # noqa: BLE001
+                    text, is_error = f"Tool error: {exc}", True
+                if on_event:
+                    on_event({"type": "tool_result", "name": tu.name, "content": text})
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tu.id,
+                    "content": text,
+                    "is_error": is_error,
+                })
+            messages.append({"role": "user", "content": tool_results})
+
+
+def run_agent(messages, api_key=None, model=None, on_event=None):
+    """
+    Synchronous entry point used by the Streamlit chat.
+
+    messages : Anthropic-format message list (mutated in place and returned).
+    Returns  : (final_answer_text, updated_messages)
+    """
+    api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError("ANTHROPIC_API_KEY is not set.")
+    model = model or DEFAULT_MODEL
+    return asyncio.run(_run(messages, api_key, model, on_event))

--- a/agent/streamlit_chat.py
+++ b/agent/streamlit_chat.py
@@ -1,0 +1,102 @@
+"""
+In-app Claude chat tab for TrackMyPDB.
+
+render() is called from streamlit_app.py's show_ai_assistant_page(). It gives
+users a chat box that talks to Claude, which in turn drives the TrackMyPDB MCP
+server tools.
+
+MIT License - Open Source Project.
+"""
+
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+from agent.mcp_agent import run_agent, DEFAULT_MODEL
+
+
+def _get_api_key():
+    try:
+        secret = st.secrets.get("ANTHROPIC_API_KEY")
+    except Exception:
+        secret = None
+    return secret or os.getenv("ANTHROPIC_API_KEY") or st.session_state.get("anthropic_api_key")
+
+
+def render():
+    st.header("TrackMyPDB AI Assistant")
+    st.caption("Chat with your data. Powered by Claude + a Model Context Protocol (MCP) server.")
+
+    api_key = _get_api_key()
+    with st.sidebar:
+        st.markdown("### AI Assistant settings")
+        if not api_key:
+            entered = st.text_input(
+                "Anthropic API key", type="password",
+                help="Create one at console.anthropic.com. Kept only in this browser session.")
+            if entered:
+                st.session_state["anthropic_api_key"] = entered
+                api_key = entered
+        model = st.text_input("Model", value=DEFAULT_MODEL,
+                              help="Any model your Anthropic account can access.")
+        if st.button("Clear chat"):
+            st.session_state["chat_messages"] = []
+            st.session_state["chat_display"] = []
+            st.rerun()
+
+    st.session_state.setdefault("chat_messages", [])   # Anthropic-format history
+    st.session_state.setdefault("chat_display", [])    # [{role, text}] for rendering
+
+    with st.expander("Example prompts", expanded=not st.session_state["chat_display"]):
+        st.markdown(
+            "- List the PDB structures for UniProt P37231.\n"
+            "- Extract the ligands from UniProt P06276 (max 3 structures).\n"
+            "- For UniProt Q9UNQ0, which ligands are most similar to aspirin "
+            "(CC(=O)OC1=CC=CC=C1C(=O)O)?\n"
+            "- How similar are caffeine and theophylline?")
+
+    for msg in st.session_state["chat_display"]:
+        with st.chat_message(msg["role"]):
+            st.markdown(msg["text"])
+
+    prompt = st.chat_input("Ask about proteins, ligands, or molecular similarity...")
+    if not prompt:
+        return
+
+    st.session_state["chat_display"].append({"role": "user", "text": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    if not api_key:
+        with st.chat_message("assistant"):
+            st.warning("Enter your Anthropic API key in the sidebar to start chatting.")
+        st.session_state["chat_display"].append(
+            {"role": "assistant", "text": "_(Waiting for an Anthropic API key.)_"})
+        return
+
+    st.session_state["chat_messages"].append({"role": "user", "content": prompt})
+
+    with st.chat_message("assistant"):
+        status = st.status("Thinking and calling TrackMyPDB tools...", expanded=True)
+
+        def on_event(ev):
+            if ev["type"] == "tool_call":
+                status.write("Calling `%s` with %s" % (ev["name"], ev["input"]))
+            elif ev["type"] == "tool_result":
+                status.write("`%s` returned %d chars" % (ev["name"], len(str(ev["content"]))))
+
+        try:
+            final_text, updated = run_agent(
+                st.session_state["chat_messages"], api_key=api_key,
+                model=model, on_event=on_event)
+            st.session_state["chat_messages"] = updated
+            status.update(label="Done", state="complete", expanded=False)
+            st.markdown(final_text)
+            st.session_state["chat_display"].append({"role": "assistant", "text": final_text})
+        except Exception as exc:  # noqa: BLE001
+            status.update(label="Error", state="error")
+            st.error("Agent error: %s" % exc)
+            st.session_state["chat_display"].append(
+                {"role": "assistant", "text": "Sorry, something went wrong: %s" % exc})

--- a/claude_desktop_config.example.json
+++ b/claude_desktop_config.example.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "trackmypdb": {
+      "command": "python",
+      "args": ["-m", "mcp_server.server"],
+      "cwd": "D:\\SKRJULY\\TrackMyPDB2\\repo"
+    }
+  }
+}

--- a/docs/AGENTIC_MCP.md
+++ b/docs/AGENTIC_MCP.md
@@ -1,0 +1,67 @@
+# TrackMyPDB - Agentic Layer & MCP Server
+
+This feature turns TrackMyPDB from a click-through Streamlit app into something
+users can **talk to**. It has two parts that share one set of tools:
+
+1. **MCP server** (`mcp_server/`) - exposes the TrackMyPDB pipeline as
+   [Model Context Protocol](https://modelcontextprotocol.io) tools over stdio.
+   Any MCP client (Claude Desktop, Cursor, ...) can use it.
+2. **Agentic chat tab** (`agent/`) - a new "AI Assistant" page in the Streamlit
+   app. It uses Claude, which calls the very same MCP server to answer.
+
+```
+                       +---------------------------+
+   Streamlit "AI       |   agent/mcp_agent.py      |
+   Assistant" tab  --> |   (Claude tool-use loop)  | --+
+                       +---------------------------+   |
+                                                       |  stdio (MCP)
+   Claude Desktop / Cursor  ----------------------------+--> mcp_server/server.py
+                                                              |
+                                                       mcp_server/core.py
+                                                              |
+                                       backend/heteroatom_extractor.py
+                                       backend/similarity_analyzer.py
+```
+
+## Tools exposed
+
+| Tool | What it does |
+|------|--------------|
+| `list_pdbs_for_uniprot` | PDB IDs for a UniProt accession |
+| `extract_heteroatoms` | Ligands + SMILES from a protein's PDB structures |
+| `analyze_similarity` | Rank ligand records vs a target SMILES (Tanimoto) |
+| `run_pipeline` | Extract + rank in one call (preferred) |
+| `compare_smiles` | Tanimoto similarity between two molecules |
+
+## Run the MCP server on its own
+
+```bat
+python -m mcp_server.server
+```
+
+It speaks JSON-RPC over stdio, so you normally launch it from an MCP client
+rather than by hand. To use it in **Claude Desktop**, copy
+`claude_desktop_config.example.json` into your Claude Desktop config
+(`%APPDATA%\Claude\claude_desktop_config.json`), fix the `cwd` path, and restart
+Claude Desktop. TrackMyPDB tools then appear in the chat.
+
+## Run the in-app chat
+
+```bat
+pip install -r requirements.txt
+set ANTHROPIC_API_KEY=sk-ant-...
+streamlit run streamlit_app.py
+```
+
+Open the app, choose **AI Assistant** in the sidebar, and chat. (You can also
+paste the key into the sidebar box instead of setting the env var.)
+
+## Design notes
+
+* `mcp_server/st_shim.py` lets the Streamlit-coupled backend run head-less in
+  the MCP process by turning every `st.*` call into a no-op. This keeps stdout
+  clean for the MCP protocol.
+* Extraction hits public APIs (RCSB, PDBe, PubChem), so tools cap the number of
+  PDB structures per UniProt ID (`max_pdbs_per_uniprot`, default 5).
+* The model name is configurable via `ANTHROPIC_MODEL`; set it to whatever your
+  account supports.

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""TrackMyPDB MCP server package (agentic + Model Context Protocol layer)."""

--- a/mcp_server/core.py
+++ b/mcp_server/core.py
@@ -1,0 +1,140 @@
+"""
+TrackMyPDB core tool functions (Streamlit-free).
+
+These wrap the existing backend classes so they run anywhere -- the MCP server,
+the in-app Claude agent, tests, or a notebook -- and return plain,
+JSON-serialisable Python objects instead of rendering Streamlit UI.
+
+MIT License - Open Source Project.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# --- Install the Streamlit shim BEFORE importing the backend ------------------
+# The backend does `import streamlit as st`. In the MCP server process there is
+# no Streamlit runtime, so we register a silent no-op shim. setdefault means:
+#   * MCP server process  -> shim is installed (streamlit not imported yet)
+#   * inside the live app -> real streamlit is already imported, so this is a
+#     no-op and the app keeps working normally.
+from . import st_shim as _st_shim
+sys.modules.setdefault("streamlit", _st_shim)
+
+from backend.heteroatom_extractor import HeteroatomExtractor  # noqa: E402
+from backend.similarity_analyzer import MolecularSimilarityAnalyzer  # noqa: E402
+
+import pandas as pd  # noqa: E402
+
+
+# ------------------------------------------------------------------ tools -----
+
+def get_pdbs_for_uniprot(uniprot_id: str) -> list:
+    """Return the list of PDB structure IDs mapped to a UniProt accession."""
+    return HeteroatomExtractor().get_pdbs_for_uniprot((uniprot_id or "").strip())
+
+
+def extract_heteroatoms(uniprot_ids, max_pdbs_per_uniprot: int = 5,
+                        drug_like_only: bool = True) -> dict:
+    """
+    Extract drug-like heteroatoms (ligands) and their SMILES from the PDB
+    structures associated with the given UniProt IDs.
+
+    max_pdbs_per_uniprot caps how many structures are downloaded per UniProt ID
+    (public APIs are slow); set to 0 for no cap.
+    """
+    if isinstance(uniprot_ids, str):
+        uniprot_ids = [uniprot_ids]
+    uniprot_ids = [u.strip() for u in uniprot_ids if u and u.strip()]
+
+    ex = HeteroatomExtractor()
+    records = []
+    pdbs_per_uniprot = {}
+
+    for up in uniprot_ids:
+        pdbs = ex.get_pdbs_for_uniprot(up)
+        if max_pdbs_per_uniprot:
+            pdbs = pdbs[:max_pdbs_per_uniprot]
+        pdbs_per_uniprot[up] = pdbs
+        for pdb in pdbs:
+            lines = ex.download_pdb(pdb)
+            if not lines:
+                continue
+            records.extend(ex.process_pdb_heteroatoms(pdb, up, lines))
+
+    if drug_like_only:
+        real = [r for r in records
+                if r.get("Heteroatom_Code") not in ("NO_DRUG_HETEROATOMS", "NO_HETEROATOMS")]
+        records = real or records
+
+    with_smiles = [r for r in records if r.get("SMILES")]
+    return {
+        "uniprot_ids": uniprot_ids,
+        "pdbs_per_uniprot": pdbs_per_uniprot,
+        "record_count": len(records),
+        "records_with_smiles": len(with_smiles),
+        "heteroatoms": records,
+    }
+
+
+def analyze_similarity(target_smiles: str, heteroatoms, top_n: int = 10,
+                       min_similarity: float = 0.0, radius: int = 2,
+                       n_bits: int = 2048) -> dict:
+    """
+    Rank the supplied heteroatom records by Tanimoto similarity (Morgan
+    fingerprints) against a target SMILES. `heteroatoms` is a list of dicts as
+    returned by extract_heteroatoms()['heteroatoms'].
+    """
+    df = pd.DataFrame(heteroatoms or [])
+    if df.empty or "SMILES" not in df.columns:
+        return {"target_smiles": target_smiles, "result_count": 0, "results": [],
+                "error": "No heteroatom records with a SMILES column were provided."}
+
+    analyzer = MolecularSimilarityAnalyzer(radius=radius, n_bits=n_bits)
+    processed = analyzer.load_and_process_dataframe(df)
+    if processed.empty:
+        return {"target_smiles": target_smiles, "result_count": 0, "results": [],
+                "error": "None of the provided SMILES could be parsed into fingerprints."}
+
+    try:
+        results = analyzer.find_similar_ligands(
+            target_smiles=target_smiles, processed_df=processed,
+            top_n=top_n, min_similarity=min_similarity)
+    except ValueError as exc:
+        return {"target_smiles": target_smiles, "result_count": 0, "results": [],
+                "error": str(exc)}
+
+    cols = [c for c in ["PDB_ID", "Heteroatom_Code", "Chemical_Name", "Formula",
+                        "SMILES", "Tanimoto_Similarity"] if c in results.columns]
+    out = results[cols].copy()
+    if "Tanimoto_Similarity" in out.columns:
+        out["Tanimoto_Similarity"] = out["Tanimoto_Similarity"].round(4)
+    return {"target_smiles": target_smiles, "result_count": int(len(out)),
+            "results": out.to_dict(orient="records")}
+
+
+def run_pipeline(uniprot_ids, target_smiles: str, max_pdbs_per_uniprot: int = 5,
+                 top_n: int = 10, min_similarity: float = 0.0, radius: int = 2,
+                 n_bits: int = 2048) -> dict:
+    """End-to-end: extract heteroatoms for UniProt IDs, then rank them by
+    similarity to a target molecule. This is the tool the agent should prefer."""
+    extraction = extract_heteroatoms(uniprot_ids, max_pdbs_per_uniprot=max_pdbs_per_uniprot)
+    similarity = analyze_similarity(target_smiles, extraction["heteroatoms"],
+                                    top_n=top_n, min_similarity=min_similarity,
+                                    radius=radius, n_bits=n_bits)
+    summary = {k: v for k, v in extraction.items() if k != "heteroatoms"}
+    return {"extraction_summary": summary, "similarity": similarity}
+
+
+def compare_smiles(smiles_a: str, smiles_b: str, radius: int = 2,
+                   n_bits: int = 2048) -> dict:
+    """Compute Tanimoto similarity between two molecules given as SMILES."""
+    analyzer = MolecularSimilarityAnalyzer(radius=radius, n_bits=n_bits)
+    fp_a = analyzer.smiles_to_fingerprint(smiles_a)
+    fp_b = analyzer.smiles_to_fingerprint(smiles_b)
+    if fp_a is None or fp_b is None:
+        return {"error": "One or both SMILES are invalid.",
+                "valid_a": fp_a is not None, "valid_b": fp_b is not None}
+    sim = analyzer.calculate_tanimoto_similarity(fp_a, fp_b)
+    return {"smiles_a": smiles_a, "smiles_b": smiles_b,
+            "tanimoto_similarity": round(float(sim), 4)}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,80 @@
+"""
+TrackMyPDB MCP server (stdio transport).
+
+Exposes the TrackMyPDB bioinformatics pipeline as Model Context Protocol tools
+so ANY MCP client -- Claude Desktop, Cursor, or the in-app Claude agent -- can
+call them. Built with the official MCP Python SDK (FastMCP).
+
+Run manually:      python -m mcp_server.server
+Claude Desktop:    see claude_desktop_config.example.json
+
+MIT License - Open Source Project.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make sure the repo root is importable when launched as a script.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp_server import core  # noqa: E402
+
+mcp = FastMCP("trackmypdb")
+
+
+@mcp.tool()
+def list_pdbs_for_uniprot(uniprot_id: str) -> dict:
+    """List the PDB structure IDs associated with a UniProt accession (e.g. P37231)."""
+    return {"uniprot_id": uniprot_id, "pdb_ids": core.get_pdbs_for_uniprot(uniprot_id)}
+
+
+@mcp.tool()
+def extract_heteroatoms(uniprot_ids: list, max_pdbs_per_uniprot: int = 5) -> dict:
+    """
+    Extract drug-like heteroatoms (ligands) and their SMILES from the PDB
+    structures of one or more UniProt proteins. Returns the ligand records plus
+    a summary. Keep max_pdbs_per_uniprot small (<=5) to stay responsive.
+    """
+    return core.extract_heteroatoms(uniprot_ids, max_pdbs_per_uniprot=max_pdbs_per_uniprot)
+
+
+@mcp.tool()
+def analyze_similarity(target_smiles: str, heteroatoms: list,
+                       top_n: int = 10, min_similarity: float = 0.0) -> dict:
+    """
+    Rank a list of heteroatom records (from extract_heteroatoms) by Tanimoto
+    similarity to a target molecule given as SMILES.
+    """
+    return core.analyze_similarity(target_smiles, heteroatoms,
+                                   top_n=top_n, min_similarity=min_similarity)
+
+
+@mcp.tool()
+def run_pipeline(uniprot_ids: list, target_smiles: str,
+                 max_pdbs_per_uniprot: int = 5, top_n: int = 10,
+                 min_similarity: float = 0.0) -> dict:
+    """
+    Full pipeline: extract heteroatoms for the given UniProt IDs, then rank them
+    by similarity to target_smiles. Prefer this when the user gives both protein
+    IDs and a target molecule.
+    """
+    return core.run_pipeline(uniprot_ids, target_smiles,
+                             max_pdbs_per_uniprot=max_pdbs_per_uniprot,
+                             top_n=top_n, min_similarity=min_similarity)
+
+
+@mcp.tool()
+def compare_smiles(smiles_a: str, smiles_b: str) -> dict:
+    """Compute the Tanimoto similarity (0-1) between two molecules given as SMILES."""
+    return core.compare_smiles(smiles_a, smiles_b)
+
+
+def main():
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/st_shim.py
+++ b/mcp_server/st_shim.py
@@ -1,0 +1,91 @@
+"""
+Streamlit shim for TrackMyPDB.
+
+The backend modules (backend/heteroatom_extractor.py and
+backend/similarity_analyzer.py) call `import streamlit as st` and render UI with
+st.info / st.progress / st.columns etc.
+
+The MCP server runs OUTSIDE any Streamlit runtime (a plain Python process
+speaking JSON-RPC over stdio). If the backend imported the real streamlit there,
+every st.* call would print a "missing ScriptRunContext" warning and could even
+write to stdout and corrupt the MCP protocol stream.
+
+This module is a drop-in replacement that turns every st.* call into a silent
+no-op. core.py installs it into sys.modules['streamlit'] BEFORE importing the
+backend, so the backend runs unchanged with zero UI side effects.
+
+MIT License - Open Source Project.
+"""
+
+from __future__ import annotations
+
+
+class _Noop:
+    """Swallows any attribute access, call, or context-manager use."""
+
+    def __call__(self, *args, **kwargs):
+        return _Noop()
+
+    def __getattr__(self, _name):
+        return _Noop()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def progress(self, *args, **kwargs):
+        return _Noop()
+
+    def empty(self, *args, **kwargs):
+        return _Noop()
+
+    def text(self, *args, **kwargs):
+        return _Noop()
+
+
+# --- functions where the SHAPE of the return value matters ---------------------
+
+def columns(spec, **kwargs):
+    """Mirror st.columns so `a, b = st.columns(2)` still unpacks correctly."""
+    n = spec if isinstance(spec, int) else len(spec)
+    return [_Noop() for _ in range(n)]
+
+
+def tabs(labels, **kwargs):
+    return [_Noop() for _ in labels]
+
+
+def progress(*args, **kwargs):
+    return _Noop()
+
+
+def empty(*args, **kwargs):
+    return _Noop()
+
+
+def spinner(*args, **kwargs):
+    return _Noop()
+
+
+def expander(*args, **kwargs):
+    return _Noop()
+
+
+def container(*args, **kwargs):
+    return _Noop()
+
+
+# namespaces / objects the backend touches by attribute
+sidebar = _Noop()
+column_config = _Noop()
+session_state = {}
+
+
+def __getattr__(name):
+    """PEP 562: anything not defined above becomes a silent no-op callable."""
+    return _Noop()

--- a/requirements-agent.txt
+++ b/requirements-agent.txt
@@ -1,0 +1,4 @@
+# Extra dependencies for the agentic + MCP layer.
+mcp>=1.2.0
+anthropic>=0.39.0
+python-dotenv>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,9 @@ seaborn>=0.12.0
 plotly>=5.15.0
 Pillow>=10.0.0
 # Updated: 2026-05-15 - Citation section prominently displayed
-# Updated: 2026-07-07 - Added Pillow, fixed libXrender.so.1 error with matplotlib Agg backend 
+# Updated: 2026-07-07 - Added Pillow, fixed libXrender.so.1 error with matplotlib Agg backend
+
+# --- Agentic + MCP layer ---
+mcp>=1.2.0
+anthropic>=0.39.0
+python-dotenv>=1.0.0 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -394,8 +394,9 @@ def main():
         "🧪 Similarity Analysis", 
         "🔬 SMILES Database Search", 
         "� Legacy Search",
-        "🖼️ Molecule Visualizer", 
-        "🏥 Disease Enrichment"
+        "🖼️ Molecule Visualizer",
+        "🏥 Disease Enrichment",
+        "🤖 AI Assistant"
     ]
     
     # Find index of current page
@@ -432,9 +433,17 @@ def main():
         show_molecule_visualizer_page()
     elif page == "🏥 Disease Enrichment":
         show_disease_enrichment_page()
-    
+    elif page == "🤖 AI Assistant":
+        show_ai_assistant_page()
+
     # Show footer
     show_footer()
+
+
+def show_ai_assistant_page():
+    """AI Assistant - Claude-powered chat backed by the TrackMyPDB MCP server."""
+    from agent.streamlit_chat import render
+    render()
 
 def show_home_page():
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,26 @@
+"""
+Offline sanity tests for the TrackMyPDB core tools.
+
+Only compare_smiles is tested here because it needs no network. Run with:
+
+    pip install pytest
+    python -m pytest tests/test_core.py -v
+"""
+
+from mcp_server import core
+
+
+def test_identical_molecules_are_perfectly_similar():
+    res = core.compare_smiles("CCO", "CCO")  # ethanol vs ethanol
+    assert res["tanimoto_similarity"] == 1.0
+
+
+def test_different_molecules_are_less_similar():
+    res = core.compare_smiles("CCO", "c1ccccc1")  # ethanol vs benzene
+    assert res["tanimoto_similarity"] < 1.0
+
+
+def test_invalid_smiles_reported():
+    res = core.compare_smiles("not_a_molecule", "CCO")
+    assert "error" in res
+    assert res["valid_b"] is True


### PR DESCRIPTION
## What
Adds an agentic layer + Model Context Protocol (MCP) server so users can
interact with TrackMyPDB through a chat interface.

## How
- `mcp_server/` : MCP server (FastMCP, stdio) exposing 5 tools:
  list_pdbs_for_uniprot, extract_heteroatoms, analyze_similarity, run_pipeline,
  compare_smiles. Reuses the existing backend via a small Streamlit shim
  (st_shim.py) so it runs head-less.
- `agent/` : a Claude tool-use loop that connects to the MCP server as a client.
- `streamlit_app.py` — new "🤖 AI Assistant" page hosting the chat.
- Works both in-app and in external MCP clients (Claude Desktop / Cursor).

## Testing
- `py -3.11 -m pytest tests/test_core.py` : 3 passed.
- Verified live: AI Assistant ran list_pdbs_for_uniprot and extract_heteroatoms
  against real UniProt IDs (P37231, P06276) end to end.

## Config
- Requires `ANTHROPIC_API_KEY`; model configurable via `ANTHROPIC_MODEL`.
- Ref: https://modelcontextprotocol.io/docs/develop/build-server